### PR TITLE
Fix crash in `WebCore::CachedResource::clearLoader()`

### DIFF
--- a/Rexxar/Core/RXRCacheFileInterceptor.m
+++ b/Rexxar/Core/RXRCacheFileInterceptor.m
@@ -91,29 +91,30 @@ static NSInteger sRegisterInterceptorCounter;
 
 + (NSURLRequest *)canonicalRequestForRequest:(NSURLRequest *)request
 {
-  RXRDebugLog(@"Intercept <%@> within <%@>", request.URL, request.mainDocumentURL);
-
-  NSMutableURLRequest *newRequest = nil;
-  if ([request isKindOfClass:[NSMutableURLRequest class]]) {
-    newRequest = (NSMutableURLRequest *)request;
-  } else {
-    newRequest = [request mutableCopy];
-  }
-
-  NSURL *localURL = [self _rxr_localFileURL:request.URL];
-  if (localURL) {
-    newRequest.URL = localURL;
-  }
-
-  [self markRequestAsIgnored:newRequest];
-  return newRequest;
+  return request;
 }
 
 - (void)startLoading
 {
   NSParameterAssert(self.dataTask == nil);
 
-  NSURLSessionTask *dataTask = [self.session dataTaskWithRequest:self.request];
+  RXRDebugLog(@"Intercept <%@> within <%@>", self.request.URL, self.request.mainDocumentURL);
+
+  NSMutableURLRequest *newRequest = nil;
+  if ([self.request isKindOfClass:[NSMutableURLRequest class]]) {
+    newRequest = (NSMutableURLRequest *)self.request;
+  } else {
+    newRequest = [self.request mutableCopy];
+  }
+
+  NSURL *localURL = [[self class] _rxr_localFileURL:self.request.URL];
+  if (localURL) {
+    newRequest.URL = localURL;
+  }
+
+  [[self class] markRequestAsIgnored:newRequest];
+
+  NSURLSessionTask *dataTask = [self.session dataTaskWithRequest:newRequest];
   [dataTask resume];
   [self setDataTask:dataTask];
 }


### PR DESCRIPTION
@lincode 

嵌入 `iframe: v.qq.com/player.html` 时，iframe 里静态文件如果已经被缓存在本地，请求地址被替换为本地文件地址，导致 `originalRequest.URL != response.URL`，跨域返回，导致静态文件的请求 `start` 后就被 `cancel` 掉了。

```
* thread #10: tid = 0x9c8c18, 0x0000000116461d30 WebCore`WebCore::CachedResource::clearLoader() + 16, name = 'WebThread', stop reason = EXC_BAD_ACCESS (code=1, address=0x390)
    frame #0: 0x0000000116461d30 WebCore`WebCore::CachedResource::clearLoader() + 16
    frame #1: 0x000000011722b2f4 WebCore`WebCore::SubresourceLoader::releaseResources() + 36
    frame #2: 0x00000001170cc94b WebCore`WebCore::ResourceLoader::cancel(WebCore::ResourceError const&) + 491
    frame #3: 0x00000001170caa14 WebCore`WebCore::ResourceLoader::cancel() + 68
  * frame #4: 0x000000011722a0f9 WebCore`WebCore::SubresourceLoader::willSendRequestInternal(WebCore::ResourceRequest&, WebCore::ResourceResponse const&) + 953
    frame #5: 0x00000001170cca75 WebCore`WebCore::ResourceLoader::willSendRequest(WebCore::ResourceHandle*, WebCore::ResourceRequest&&, WebCore::ResourceResponse&&) + 69
    frame #6: 0x00000001170c8714 WebCore`WebCore::ResourceHandle::willSendRequest(WebCore::ResourceRequest&&, WebCore::ResourceResponse&&) + 1220
    frame #7: 0x00000001173c283d WebCore`-[WebCoreResourceHandleAsDelegate connection:willSendRequest:redirectResponse:] + 221
    frame #8: 0x000000011344d87d CFNetwork`___ZL31_NSURLConnectionWillSendRequestP16_CFURLConnectionPK13_CFURLRequestP14_CFURLResponsePKv_block_invoke + 146
    frame #9: 0x000000011344d7c0 CFNetwork`__65-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]_block_invoke + 72
    frame #10: 0x000000011344d6d2 CFNetwork`-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:] + 199
    frame #11: 0x000000011344d5f9 CFNetwork`-[NSURLConnectionInternal _withActiveConnectionAndDelegate:] + 48
    frame #12: 0x000000011344d590 CFNetwork`_NSURLConnectionWillSendRequest(_CFURLConnection*, _CFURLRequest const*, _CFURLResponse*, void const*) + 126
    frame #13: 0x00000001135e9663 CFNetwork`URLConnectionClient_Classic::_connectionClientInterface_precanonicalizeForSynchronousStart() + 305
    frame #14: 0x000000011344aa24 CFNetwork`ClassicURLConnection::start() + 228
    frame #15: 0x000000011344a8fe CFNetwork`CFURLConnectionStart + 45
    frame #16: 0x000000011344a8c0 CFNetwork`-[NSURLConnectionInternalConnection start] + 79
    frame #17: 0x000000010a9fdf5c Frodo`-[_priv_NSURLConnection_NBS nbs_start] + 876
    frame #18: 0x00000001170c7811 WebCore`WebCore::ResourceHandle::start() + 705
    frame #19: 0x00000001170c55ad WebCore`WebCore::ResourceHandle::create(WebCore::NetworkingContext*, WebCore::ResourceRequest const&, WebCore::ResourceHandleClient*, bool, bool) + 557
    frame #20: 0x00000001170cacb7 WebCore`WebCore::ResourceLoader::start() + 343
    frame #21: 0x0000000117229cea WebCore`WebCore::SubresourceLoader::startLoading() + 234
    frame #22: 0x000000011625a2b4 WebKitLegacy`WebResourceLoadScheduler::servePendingRequests(WebResourceLoadScheduler::HostInformation*, WebCore::ResourceLoadPriority) + 564
    frame #23: 0x0000000116259d87 WebKitLegacy`WebResourceLoadScheduler::loadResource(WebCore::Frame&, WebCore::CachedResource&, WebCore::ResourceRequest const&, WebCore::ResourceLoaderOptions const&) + 55
    frame #24: 0x000000011646115f WebCore`WebCore::CachedResource::load(WebCore::CachedResourceLoader&, WebCore::ResourceLoaderOptions const&) + 1263
    frame #25: 0x0000000116465eb4 WebCore`WebCore::CachedResourceLoader::requestResource(WebCore::CachedResource::Type, WebCore::CachedResourceRequest&) + 2628
    frame #26: 0x0000000116466615 WebCore`WebCore::CachedResourceLoader::requestScript(WebCore::CachedResourceRequest&) + 37
    frame #27: 0x00000001171047d3 WebCore`WebCore::ScriptElement::requestScript(WTF::String const&) + 1795
    frame #28: 0x0000000117103234 WebCore`WebCore::ScriptElement::prepareScript(WTF::TextPosition const&, WebCore::ScriptElement::LegacyTypeSupport) + 612
    frame #29: 0x0000000117102fbb WebCore`WebCore::ScriptElement::finishedInsertingSubtree() + 27
    frame #30: 0x00000001164bf75c WebCore`WebCore::ContainerNode::notifyChildInserted(WebCore::Node&, WebCore::ContainerNode::ChildChangeSource) + 332
    frame #31: 0x00000001164bf25e WebCore`WebCore::ContainerNode::updateTreeAfterInsertion(WebCore::Node&) + 30
    frame #32: 0x00000001164bf19d WebCore`WebCore::ContainerNode::appendChild(WebCore::Node&, int&) + 957
    frame #33: 0x0000000116e863c8 WebCore`WebCore::Node::appendChild(WebCore::Node&, int&) + 24
    frame #34: 0x0000000116c35534 WebCore`WebCore::JSNode::appendChild(JSC::ExecState&) + 68
    frame #35: 0x0000018ea272d6c8
    frame #36: 0x000000011b0ee3a5 JavaScriptCore`llint_entry + 24967
    frame #37: 0x000000011b0ee3a5 JavaScriptCore`llint_entry + 24967
    frame #38: 0x000000011b0ee3a5 JavaScriptCore`llint_entry + 24967
    frame #39: 0x000000011b0ee3a5 JavaScriptCore`llint_entry + 24967
    frame #40: 0x000000011b0ee3a5 JavaScriptCore`llint_entry + 24967
    frame #41: 0x000000011b0e803b JavaScriptCore`vmEntryToJavaScript + 299
    frame #42: 0x000000011af6967e JavaScriptCore`JSC::JITCode::execute(JSC::VM*, JSC::ProtoCallFrame*) + 158
    frame #43: 0x000000011af2d2ee JavaScriptCore`JSC::Interpreter::execute(JSC::ProgramExecutable*, JSC::ExecState*, JSC::JSObject*) + 16382
    frame #44: 0x000000011accb056 JavaScriptCore`JSC::evaluate(JSC::ExecState*, JSC::SourceCode const&, JSC::JSValue, WTF::NakedPtr<JSC::Exception>&) + 470
    frame #45: 0x00000001170febcf WebCore`WebCore::ScriptController::evaluateInWorld(WebCore::ScriptSourceCode const&, WebCore::DOMWrapperWorld&, WebCore::ExceptionDetails*) + 287
    frame #46: 0x0000000117104ae3 WebCore`WebCore::ScriptElement::executeScript(WebCore::ScriptSourceCode const&) + 563
    frame #47: 0x00000001171033fa WebCore`WebCore::ScriptElement::prepareScript(WTF::TextPosition const&, WebCore::ScriptElement::LegacyTypeSupport) + 1066
    frame #48: 0x00000001168edac2 WebCore`WebCore::HTMLScriptRunner::runScript(WebCore::Element*, WTF::TextPosition const&) + 338
    frame #49: 0x00000001168ed920 WebCore`WebCore::HTMLScriptRunner::execute(WTF::PassRefPtr<WebCore::Element>, WTF::TextPosition const&) + 48
    frame #50: 0x0000000116888c26 WebCore`WebCore::HTMLDocumentParser::runScriptsForPausedTreeBuilder() + 86
    frame #51: 0x0000000116888f5b WebCore`WebCore::HTMLDocumentParser::pumpTokenizerLoop(WebCore::HTMLDocumentParser::SynchronousMode, bool, WebCore::PumpSession&) + 715
    frame #52: 0x0000000116888a43 WebCore`WebCore::HTMLDocumentParser::pumpTokenizer(WebCore::HTMLDocumentParser::SynchronousMode) + 115
    frame #53: 0x000000011688988a WebCore`WebCore::HTMLDocumentParser::resumeParsingAfterScriptExecution() + 122
    frame #54: 0x0000000116889b06 WebCore`non-virtual thunk to WebCore::HTMLDocumentParser::notifyFinished(WebCore::CachedResource*) + 86
    frame #55: 0x00000001164614a5 WebCore`WebCore::CachedResource::checkNotify() + 501
    frame #56: 0x000000011722a692 WebCore`WebCore::SubresourceLoader::didFinishLoading(double) + 1218
    frame #57: 0x000000011344d7c0 CFNetwork`__65-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:]_block_invoke + 72
    frame #58: 0x000000011344d6d2 CFNetwork`-[NSURLConnectionInternal _withConnectionAndDelegate:onlyActive:] + 199
    frame #59: 0x000000011344d5f9 CFNetwork`-[NSURLConnectionInternal _withActiveConnectionAndDelegate:] + 48
    frame #60: 0x0000000113451b9e CFNetwork`___ZN27URLConnectionClient_Classic26_delegate_didFinishLoadingEU13block_pointerFvvE_block_invoke + 104
    frame #61: 0x00000001135e5271 CFNetwork`___ZN27URLConnectionClient_Classic18_withDelegateAsyncEPKcU13block_pointerFvP16_CFURLConnectionPK33CFURLConnectionClientCurrent_VMaxE_block_invoke_2 + 100
    frame #62: 0x0000000112d480cd libdispatch.dylib`_dispatch_client_callout + 8
    frame #63: 0x0000000112d229a0 libdispatch.dylib`_dispatch_block_invoke_direct + 567
    frame #64: 0x000000011344d4c4 CFNetwork`RunloopBlockContext::_invoke_block(void const*, void*) + 24
    frame #65: 0x00000001110413f4 CoreFoundation`CFArrayApplyFunction + 68
    frame #66: 0x000000011344d3bd CFNetwork`RunloopBlockContext::perform() + 137
    frame #67: 0x000000011344d256 CFNetwork`MultiplexerSource::perform() + 282
    frame #68: 0x000000011344d078 CFNetwork`MultiplexerSource::_perform(void*) + 72
    frame #69: 0x0000000111095761 CoreFoundation`__CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 17
    frame #70: 0x000000011107a98c CoreFoundation`__CFRunLoopDoSources0 + 556
    frame #71: 0x0000000111079e76 CoreFoundation`__CFRunLoopRun + 918
    frame #72: 0x0000000111079884 CoreFoundation`CFRunLoopRunSpecific + 420
    frame #73: 0x00000001173c67f5 WebCore`RunWebThread(void*) + 469
    frame #74: 0x0000000113185aab libsystem_pthread.dylib`_pthread_body + 180
    frame #75: 0x00000001131859f7 libsystem_pthread.dylib`_pthread_start + 286
    frame #76: 0x00000001131851fd libsystem_pthread.dylib`thread_start + 13
```