### PR TITLE
Fix picking latest routes when cache routes version is empty

### DIFF
--- a/Rexxar/Core/RXRRouteManager.m
+++ b/Rexxar/Core/RXRRouteManager.m
@@ -279,6 +279,8 @@
       } else {
         routesObject = cacheRoutesObject;
       }
+    } else if (cacheRoutesObject.version.length == 0 && resourceRoutesObject.version.length > 0) {
+      routesObject = resourceRoutesObject;
     } else {
       routesObject = cacheRoutesObject;
     }


### PR DESCRIPTION
如果本地缓存 routes.json 文件里没有 version 信息，优先使用有 version 信息的 routes @hao-feng 